### PR TITLE
Fixes keypress on lines that already have semicolon being ignored

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,9 +1,7 @@
 const vscode = require('vscode');
 
 function colonize( option ) {
-
     var editor = vscode.window.activeTextEditor;
-
     if ( !editor ) return;
 
     var lineIndex = editor.selection.active.line;

--- a/extension.js
+++ b/extension.js
@@ -1,22 +1,22 @@
 const vscode = require('vscode');
 
 function colonize( option ) {
-    
+
     var editor = vscode.window.activeTextEditor;
-    
+
     if ( !editor ) return;
 
     var lineIndex = editor.selection.active.line;
     var lineObject = editor.document.lineAt( lineIndex );
     var lineLength = lineObject.text.length;
 
-    if ( lineObject.text.charAt( lineLength - 1 ) == ";" || lineObject.isEmptyOrWhitespace ) return;
+    if ( lineObject.text.charAt( lineLength - 1 ) != ";" && !lineObject.isEmptyOrWhitespace ) {
+        var semiResult = editor.edit( ( editBuilder ) => {
+            editBuilder.insert(new vscode.Position( lineIndex, lineLength ), ";");
+        });
 
-    var semiResult = editor.edit( ( editBuilder ) => {
-        editBuilder.insert(new vscode.Position( lineIndex, lineLength ), ";");
-    });
-
-    if ( !semiResult ) return;
+        if ( !semiResult ) return;
+    }
 
     var cursorResult;
 


### PR DESCRIPTION
Based on the current code, if one of the shortcut keys is pressed and the line already has a semicolon, the keypress is ignored and the cursor doesn't move. I believe that the editor shortcut should still apply the same way in both cases. 

This PR changes the `;` insertion so that the cursor moves as expected whether the semicolon was added or was already there. 