### PR TITLE
Fixes keypress not accepting current Intellisense autocomplete

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,9 +1,7 @@
 const vscode = require('vscode');
 
 function colonize( option ) {
-    
     var editor = vscode.window.activeTextEditor;
-    
     if ( !editor ) return;
 
     var lineIndex = editor.selection.active.line;
@@ -17,6 +15,8 @@ function colonize( option ) {
     });
 
     if ( !semiResult ) return;
+
+    vscode.commands.executeCommand('acceptSelectedSuggestion');
 
     var cursorResult;
 


### PR DESCRIPTION
If one of the shortcut keys is pressed while there is an Intellisense suggestion selected, the suggestion currently will not be completed. This PR executes the vscode command to accept the current suggestion before running the cursor change command. 

```csharp
// Starting code: 
_myVar = something;
DoSomething(_myV)

// Current functionality, Alt+Enter
DoSomething(_myV);
// cursor here, no autocomplete

// Patch functionality, Alt+Enter
DoSomething(_myVar);
// cursor here, _myVar was autocompleted based on currently selected Intellisense