### PR TITLE
Support for Flutter and dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
-All notable changes to the "Colonize" extension will be documented in this file.
+All notable changes to the "colonize" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
-All notable changes to the "colonize" extension will be documented in this file.
+All notable changes to the "Colonize" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **colonize**
+# **Colonize**
 
 ![showcase](images/showcase.gif)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# **Colonize**
+# **colonize**
 
 ![showcase](images/showcase.gif)
 
 ## Features
 
-- Adds three shotcuts to insert semicolons with ease;
+***Support for Flutter and dart***
+
+- Adds three shortcuts to insert semicolons with ease;
+- Depends on coma position in line. If there is coma before close bracket (,) put a coma end of the line otherwise puts a semicolon.
 
   - <kbd>shift</kbd> + <kbd>enter</kbd> Insert semicolon at the end of line and continue on the same line
   - <kbd>alt</kbd> + <kbd>enter</kbd> Insert semicolon at the end of line and continue on the new line

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ***Support for Flutter and dart***
 
 - Adds three shortcuts to insert semicolons with ease;
-- Depends on coma position in line. If there is coma before close bracket (,) put a coma end of the line otherwise puts a semicolon.
+- Depends on comma position in line. If there is comma before close bracket (,) put a comma end of the line otherwise puts a semicolon.
 
   - <kbd>shift</kbd> + <kbd>enter</kbd> Insert semicolon at the end of line and continue on the same line
   - <kbd>alt</kbd> + <kbd>enter</kbd> Insert semicolon at the end of line and continue on the new line

--- a/extension.js
+++ b/extension.js
@@ -9,9 +9,13 @@ function colonize (option) {
     var lineObject = editor.document.lineAt(lineIndex)
     var lineLength = lineObject.text.length
 
-    if (lineObject.text.charAt(lineLength - 1) !== ';' && !lineObject.isEmptyOrWhitespace) {
+    if (lineObject.text.charAt(lineLength - 1) !== ';' && lineObject.text.charAt(lineLength - 1) !== ',' && !lineObject.isEmptyOrWhitespace) {
       var insertionSuccess = editor.edit((editBuilder) => {
-        editBuilder.insert(new vscode.Position(lineIndex, lineLength), ';')
+        if(lineObject.text.charAt(lineLength - 2) === ',') {
+          editBuilder.insert(new vscode.Position(lineIndex, lineLength), ',')
+        } else {
+          editBuilder.insert(new vscode.Position(lineIndex, lineLength), ';')
+        }
       })
 
       if (!insertionSuccess) return

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "colonize",
-  "displayName": "colonize",
-  "description": "Adds semicolon or coma at the end of the line and optionally newline after",
+  "displayName": "Colonize",
+  "description": "Adds semicolon or comma at the end of the line and optionally newline after",
   "version": "2.2.2",
-  "publisher": "tasty",
+  "publisher": "vmsynkov",
   "license": "GPL-3.0",
   "main": "./extension",
   "scripts": {
@@ -47,16 +47,16 @@
   "contributes": {
     "commands": [
       {
-        "command": "Colonize.endline",
-        "title": "colonize and Jump to End"
+        "command": "colonize.endline",
+        "title": "Colonize and Jump to End"
       },
       {
-        "command": "Colonize.newline",
-        "title": "colonize and Jump to Newline"
+        "command": "colonize.newline",
+        "title": "Colonize and Jump to Newline"
       },
       {
-        "command": "Colonize.hold",
-        "title": "colonize and Hold position"
+        "command": "colonize.hold",
+        "title": "Colonize and Hold position"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "colonize",
-  "displayName": "Colonize",
-  "description": "Adds semicolon at the end of the line and optionally newline after",
+  "displayName": "colonize",
+  "description": "Adds semicolon or coma at the end of the line and optionally newline after",
   "version": "2.2.2",
-  "publisher": "vmsynkov",
+  "publisher": "tasty",
   "license": "GPL-3.0",
   "main": "./extension",
   "scripts": {
@@ -48,15 +48,15 @@
     "commands": [
       {
         "command": "colonize.endline",
-        "title": "Colonize and Jump to End"
+        "title": "colonize and Jump to End"
       },
       {
         "command": "colonize.newline",
-        "title": "Colonize and Jump to Newline"
+        "title": "colonize and Jump to Newline"
       },
       {
         "command": "colonize.hold",
-        "title": "Colonize and Hold position"
+        "title": "colonize and Hold position"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -47,15 +47,15 @@
   "contributes": {
     "commands": [
       {
-        "command": "colonize.endline",
+        "command": "Colonize.endline",
         "title": "colonize and Jump to End"
       },
       {
-        "command": "colonize.newline",
+        "command": "Colonize.newline",
         "title": "colonize and Jump to Newline"
       },
       {
-        "command": "colonize.hold",
+        "command": "Colonize.hold",
         "title": "colonize and Hold position"
       }
     ],


### PR DESCRIPTION
put a comma instead of a semicolon if there is a comma before. do it while keeping prior functionality.